### PR TITLE
PIO assemble: shift `Set_Wrap` addresses by `Program_Offset`

### DIFF
--- a/pio_assemble/src/main.adb
+++ b/pio_assemble/src/main.adb
@@ -28,8 +28,8 @@ begin
    Set_Out_Pins (Config, Pico.LED.Pin, 1);
    Set_Set_Pins (Config, Pico.LED.Pin, 1);
    Set_Wrap (Config,
-      Wrap_Target => 0,
-      Wrap        => Blink_Program'Length);
+      Wrap_Target => Program_Offset,
+      Wrap        => Program_Offset + Blink_Program'Length);
    Set_Clock_Frequency (Config, 50_000_000);
 
    P.SM_Initialize (SM,


### PR DESCRIPTION
In this example, the program is added at program offset 0, so it _works_ with the hard-coded zero and `Blink_Program'Length` wraps, but becomes a bug when another PIO program is added and the offset changes. Adding the `Program_Offset` keeps them in line.

PS `rp2040_hal` is awesome! I'm trying Ada for the first time with it and really enjoying it :)